### PR TITLE
fix: make docker install work on Amazon Linux 2023 (default image)

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -86,7 +86,10 @@ EOF`,
       }
       if (preinstalledSoftware.packages?.includes(PreinstalledSoftwarePackage.DOCKER)) {
         userData.addCommands(
-          'sudo amazon-linux-extras install docker',
+          // Amazon Linux 2023 (the default image) uses dnf and has docker in its
+          // default repositories, while Amazon Linux 2 installs docker via
+          // amazon-linux-extras. Pick the right command at runtime so both work.
+          'if command -v dnf >/dev/null 2>&1; then sudo dnf install -y docker; else sudo amazon-linux-extras install -y docker; fi',
           'sudo systemctl start docker',
           'sudo systemctl enable docker',
           'sudo usermod -a -G docker ec2-user',


### PR DESCRIPTION
## Problem

The optional software installer's `DOCKER` preinstalled package used:

```sh
sudo amazon-linux-extras install docker
```

`amazon-linux-extras` exists **only on Amazon Linux 2**. Because Amazon Linux 2023 is the construct's **default** machine image, selecting `PreinstalledSoftwarePackage.DOCKER` on the default OS fails at provisioning time.

## Fix

Choose the install command at runtime so it works on **both** supported images:

```sh
if command -v dnf >/dev/null 2>&1; then sudo dnf install -y docker; else sudo amazon-linux-extras install -y docker; fi
```

- **Amazon Linux 2023**: `dnf` is present and docker is in the default repos -> `dnf install -y docker`.
- **Amazon Linux 2**: `dnf` absent -> falls back to `amazon-linux-extras install -y docker`.

`systemctl start/enable docker` and the `usermod` group line are unchanged.

## Scope notes

- Only `amazon-linux-extras` usage in the codebase was this Docker line; no other AL2-only commands needed changing.
- No unit tests exist. The integ test does not enable the `DOCKER` package, so the integ snapshot user-data is unaffected (snapshot verification passes unchanged).

## Verification

`npx projen build` fully green: compile + eslint + jest + integ snapshot verify (1 passed) + package (js/python).